### PR TITLE
Revert "fix: handle correctly thousands of phonebook contacts"

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,2 +1,0 @@
-max_execution_time=60
-memory_limit=512M

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: heroku-php-apache2 -C apache_conf/override.conf

--- a/apache_conf/override.conf
+++ b/apache_conf/override.conf
@@ -1,2 +1,0 @@
-DirectoryIndex index.php index.html index.htm
-TimeOut 90

--- a/index.php
+++ b/index.php
@@ -430,7 +430,7 @@ function handle($data)
 
             // set headers
             header("Content-type: application/json");
-            header("Last-Modified: " . gmdate('D, d M Y H:i:s') . ' GMT');
+            header("Last-Modified: " . date(DATE_RFC2822));
             header('HTTP/1.1 200 OK');
 
             // print results


### PR DESCRIPTION
Reverts nethesis/ctiapp-authproxy#13

These changes were meant to optimize caching in scenarios with many contacts, but since the headers are stripped by DigitalOcean’s Cloudflare, this PR becomes redundant. A new approach is needed, or alternatively a dedicated droplet should be used.